### PR TITLE
change threshold_proportional to use numpy's (bankers') rounding

### DIFF
--- a/bct/utils/other.py
+++ b/bct/utils/other.py
@@ -94,7 +94,7 @@ def threshold_proportional(W, p, copy=True):
 
     I = np.argsort(W[ind])[::-1]		# sort indices by magnitude
 
-    en = int(round((n * n - n) * p / ud))		# number of links to be preserved
+    en = int(np.round((n * n - n) * p / ud))		# number of links to be preserved
 
     W[(ind[0][I][en:], ind[1][I][en:])] = 0  # apply threshold
     #W[np.ix_(ind[0][I][en:], ind[1][I][en:])]=0

--- a/test/core_tests.py
+++ b/test/core_tests.py
@@ -6,7 +6,7 @@ import numpy as np
 def test_threshold_proportional():
     x = load_sample()
     x = bct.threshold_proportional(x, .5, copy=True)
-    assert np.allclose(np.sum(x), 22548.51206965)
+    assert np.allclose(np.sum(x), 22544.8029284)
 
 
 def test_threshold_proportional_nocopy():


### PR DESCRIPTION
This will resolve #28 when the changes are propagated to the py3 branch. See [this comment](https://github.com/aestrivex/bctpy/issues/28#issuecomment-155193244) for design discussion (spoiler: it's a departure from matlab behaviour).