### PR TITLE
Fix agreement() for internally consistent dimensions

### DIFF
--- a/bct/algorithms/clustering.py
+++ b/bct/algorithms/clustering.py
@@ -5,7 +5,7 @@ from bct.utils import cuberoot, BCTParamError, dummyvar, binarize
 from .distance import breadthdist
 
 
-def agreement(ci, buffsz=None):
+def agreement(ci, buffsz=1000):
     '''
     Takes as input a set of vertex partitions CI of
     dimensions [vertex x partition]. Each column in CI contains the
@@ -22,7 +22,7 @@ def agreement(ci, buffsz=None):
 
     Parameters
     ----------
-    ci : MxN np.ndarray
+    ci : NxM np.ndarray
         set of M (possibly degenerate) partitions of N nodes
     buffsz : int | None
         sets buffer size. If not specified, defaults to 1000
@@ -33,22 +33,19 @@ def agreement(ci, buffsz=None):
         agreement matrix
     '''
     ci = np.array(ci)
-    m, n = ci.shape
+    n_nodes, n_partitions = ci.shape
 
-    if buffsz is None:
-        buffsz = 1000
-
-    if m <= buffsz:
+    if n_partitions <= buffsz: # Case 1: Use all partitions at once
         ind = dummyvar(ci)
         D = np.dot(ind, ind.T)
-    else:
-        a = np.arange(0, m, buffsz)
-        b = np.arange(buffsz, m, buffsz)
+    else: # Case 2: Add together results from subsets of partitions
+        a = np.arange(0, n_partitions, buffsz)
+        b = np.arange(buffsz, n_partitions, buffsz)
         if len(a) != len(b):
-            b = np.append(b, m)
-        D = np.zeros((n,))
+            b = np.append(b, n_partitions)
+        D = np.zeros((n_nodes, n_nodes))
         for i, j in zip(a, b):
-            y = ci[:, i:j + 1]
+            y = ci[:, i:j]
             ind = dummyvar(y)
             D += np.dot(ind, ind.T)
 

--- a/test/clustering_tests.py
+++ b/test/clustering_tests.py
@@ -104,3 +104,42 @@ def test_transitivity_bd():
 def test_agreement_weighted():
     # this function is very hard to use or interpret results from
     pass
+
+def test_agreement():
+    # Case 1: nodes > partitions
+    input_1 = np.array([[1, 1, 1],
+                        [1, 2, 2]]).T
+    correct_1 = np.array([[0, 1, 1],
+                          [1, 0, 2],
+                          [1, 2, 0]])
+
+    # Case 2: partitions > nodes
+    input_2 = np.array([[1, 1, 1],
+                        [1, 2, 2],
+                        [2, 2, 1],
+                        [1, 2, 2]]).T
+    correct_2 = np.array([[0, 2, 1],
+                          [2, 0, 3],
+                          [1, 3, 0]])
+
+    print('correct:')
+    print(correct_1)
+    output_1 = bct.agreement(input_1)
+    print('outputs:')
+    print(output_1)
+    assert (output_1 == correct_1).all()
+    for buffsz in range(1, 3):
+        output_1_buffered = bct.agreement(input_1, buffsz=buffsz)
+        print(output_1_buffered)
+        assert (output_1_buffered == correct_1).all()
+
+    print('correct:')
+    print(correct_2)
+    output_2 = bct.agreement(input_2)
+    print('outputs:')
+    print(output_2)
+    assert (output_2 == correct_2).all()
+    for buffsz in range(1, 5):
+        output_2_buffered = bct.agreement(input_2, buffsz=buffsz)
+        print(output_2_buffered)
+        assert (output_2_buffered == correct_2).all()


### PR DESCRIPTION
Currently the doctoring mentions that agreement 
```'''Takes as input a set of vertex partitions CI of dimensions [vertex x partition]'''```
while later Parameters defines CI as:
```
'''
ci : MxN np.ndarray
        set of M (possibly degenerate) partitions of N nodes
'''
```

The cases of whether to split CI based on buffsz appear to be broken. The first case only gives the correct result if the matrix is [nodes * partitions]. The second case is indexing into the second axis to select a partition range, but also using the size of that second dimension for the size of D, which should be (nodes*nodes), which seems incorrect.

Chose the option that was consistent with usage inside consensus_und (nodes by partitions) and added a couple short tests.
