### PR TITLE
Corrected masking for NaN in charpath.

### DIFF
--- a/bct/algorithms/distance.py
+++ b/bct/algorithms/distance.py
@@ -155,7 +155,7 @@ def charpath(D, include_diagonal=False, include_infinite=True):
     efficiency = np.mean(1 / Dv)
 
     # eccentricity for each vertex (ignore inf)
-    ecc = np.array(np.ma.masked_equal(D, np.nan).max(axis=1))
+    ecc = np.array(np.ma.masked_where(np.isnan(D), D).max(axis=1))
 
     # radius of graph
     radius = np.min(ecc)  # but what about zeros?

--- a/test/distance_tests.py
+++ b/test/distance_tests.py
@@ -44,3 +44,14 @@ def test_distance_wei():
 
     assert np.allclose(np.sum(d), 155650.1, atol=.01)
     assert np.sum(e) == 30570
+
+def test_charpath():
+    x = load_sample(thres=.02)
+    d, e = bct.distance_wei(x)
+    l, eff,ecc,radius,diameter = bct.charpath(d)
+
+    assert np.any(np.isinf(d))
+    assert not np.isnan(radius)
+    assert not np.isnan(diameter)
+
+


### PR DESCRIPTION
I've fixed a small bug in charpath, where the nan values were incorrectly masked resulting in eccentricity arrays filled only with nans. Nan is a funny creature, when it comes to comparison and testing for equality.

Cheers,
Jan Fousek