### PR TITLE
Switch from nose to pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 scipy
-nose
+pytest
 setuptools
 tox

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -1,4 +1,4 @@
-from load_samples import *
+from .load_samples import load_sample, load_directed_sample
 import bct
 import numpy as np
 

--- a/test/clustering_test.py
+++ b/test/clustering_test.py
@@ -1,4 +1,7 @@
-from load_samples import *
+from .load_samples import (
+    load_sample, load_signed_sample, load_sparse_sample,
+    load_directed_low_modularity_sample, load_binary_directed_low_modularity_sample
+)
 import numpy as np
 import bct
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--skiplong", action="store_true", default=False, help="skip long-running tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption('--skiplong'):
+        return
+    skip = pytest.mark.skip(reason="skipping long-running tests")
+    for item in items:
+        if "long" in item.keywords:
+            item.add_marker(skip)

--- a/test/core_test.py
+++ b/test/core_test.py
@@ -1,4 +1,4 @@
-from load_samples import *
+from .load_samples import load_sample
 import bct
 import numpy as np
 

--- a/test/distance_test.py
+++ b/test/distance_test.py
@@ -1,4 +1,4 @@
-from load_samples import *
+from .load_samples import load_sample
 import numpy as np
 import bct
 
@@ -45,6 +45,7 @@ def test_distance_wei():
     assert np.allclose(np.sum(d), 155650.1, atol=.01)
     assert np.sum(e) == 30570
 
+
 def test_charpath():
     x = load_sample(thres=.02)
     d, e = bct.distance_wei(x)
@@ -53,5 +54,3 @@ def test_charpath():
     assert np.any(np.isinf(d))
     assert not np.isnan(radius)
     assert not np.isnan(diameter)
-
-

--- a/test/load_samples.py
+++ b/test/load_samples.py
@@ -2,11 +2,15 @@ import numpy as np
 import bct
 import os
 
-MAT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'mats')
-mat_path = lambda fname: os.path.join(MAT_DIR, fname)
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+MAT_DIR = os.path.join(TEST_DIR, 'mats')
 
 
-def load_sample(thres=1):
+def mat_path(fname):
+    return os.path.join(MAT_DIR, fname)
+
+
+def load_sample(thres=1.):
     return bct.threshold_proportional(np.load(mat_path('sample_data.npy')),
                                       thres, copy=False)
 
@@ -24,7 +28,7 @@ def load_binary_sample(thres=.35):
     return bct.binarize(load_sample(thres=thres), copy=False)
 
 
-def load_directed_sample(thres=1):
+def load_directed_sample(thres=1.):
     return bct.threshold_proportional(np.load(mat_path('sample_directed.npy')),
                                       thres, copy=False)
 
@@ -33,7 +37,7 @@ def load_binary_directed_sample(thres=.35):
     return bct.binarize(load_directed_sample(thres=thres))
 
 
-def load_directed_low_modularity_sample(thres=1):
+def load_directed_low_modularity_sample(thres=1.):
     return bct.threshold_proportional(np.load(
         mat_path('sample_directed_gc.npy')), thres, copy=False)
 

--- a/test/modularity_derived_metrics_test.py
+++ b/test/modularity_derived_metrics_test.py
@@ -1,4 +1,4 @@
-from load_samples import *
+from .load_samples import load_sample, mat_path
 import numpy as np
 import bct
 
@@ -16,7 +16,7 @@ def test_pc():
     assert np.allclose(pc, pc_, atol=0.02)
 
 
-def participation_test():
+def test_participation():
     W = np.eye(3)
     ci = np.array([1, 1, 2])
 
@@ -43,7 +43,7 @@ def participation_test():
     assert np.allclose(bct.participation_coef_sign(W, ci)[0], [0.,  0.5,  0.])
 
 
-def gateway_test():
+def test_gateway():
     x = load_sample(thres=.1)
     ci = np.load(mat_path('sample_partition.npy'))
 

--- a/test/modularity_test.py
+++ b/test/modularity_test.py
@@ -1,4 +1,4 @@
-from load_samples import *
+from .load_samples import load_sample, load_directed_sample, load_signed_sample, load_directed_low_modularity_sample
 import numpy as np
 import bct
 

--- a/test/nbs_test.py
+++ b/test/nbs_test.py
@@ -1,4 +1,4 @@
-from load_samples import *
+from .load_samples import load_sample_group_dsi, load_sample_group_fmri, load_sample_group_qball
 import numpy as np
 import bct
 

--- a/test/nodals_test.py
+++ b/test/nodals_test.py
@@ -1,4 +1,4 @@
-from load_samples import *
+from .load_samples import load_sample
 import numpy as np
 import bct
 

--- a/test/partition_distance_test.py
+++ b/test/partition_distance_test.py
@@ -1,4 +1,4 @@
-from load_samples import *
+from .load_samples import load_sample_group_qball, load_sample_group_dsi
 import numpy as np
 import bct
 

--- a/test/reference_test.py
+++ b/test/reference_test.py
@@ -1,6 +1,6 @@
-from unittest import skip
+import pytest
 
-from load_samples import *
+from .load_samples import *
 import numpy as np
 import bct
 
@@ -8,7 +8,7 @@ import bct
 SEED = 1
 
 
-@skip("unfixed bug #68")
+@pytest.mark.xfail(reason="unfixed bug #68")
 def test_null_model_und_sign():
     # Regression test for bug fixed in b02a306
     x = load_sample(thres=.4)
@@ -16,7 +16,7 @@ def test_null_model_und_sign():
     bct.null_model_und_sign(x)
 
 
-@skip("unfixed bug #68")
+@pytest.mark.xfail(reason="unfixed bug #68")
 def test_null_model_dir_sign():
     # Regression test for counterpart to the undirected bug
     x = load_directed_sample(thres=.4)

--- a/test/very_long_test.py
+++ b/test/very_long_test.py
@@ -1,8 +1,12 @@
-from load_samples import *
+import pytest
 import numpy as np
+
 import bct
 
+from .load_samples import load_sample
 
+
+@pytest.mark.long
 def test_link_communities():
     x = load_sample(thres=0.4)
     seed = 949389104

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ deps = -rrequirements.txt
 commands =
     pip install -U pip
     pip install .
-    nosetests --ignore-files="very_long_tests" -v
+    pytest --skiplong -v


### PR DESCRIPTION
The nose project is dead, and nose2 isn't designed for full compatibility with nose.

Pytest is active: the maintainers of nose2 recommend using pytest.

A couple of visible improvements here include

- proper module imports for `load_samples` (I don't know about you, but my IDE couldn't introspect the old layout), which broke nose's test discovery
- xfail, distinct from skip
- more flexibility in marking tests as "long", so they don't have to be all in the same file

Also changed the names of a few files and tests for consistency/ compatibility.