### PR TITLE
null_model_und_sign casting error

### DIFF
--- a/bct/algorithms/reference.py
+++ b/bct/algorithms/reference.py
@@ -1058,7 +1058,7 @@ def null_model_und_sign(W, bin_swaps=5, wei_freq=.1, seed=None):
             W0.flat[Lij[Oind]] = s * Wv  # weight at this index
         else:
             wsize = np.size(Wv)
-            wei_period = np.round(1 / wei_freq)  # convert frequency to period
+            wei_period = np.round(1 / wei_freq).astype(int)  # convert frequency to period
             lq = np.arange(wsize, 0, -wei_period, dtype=int)
             for m in lq:  # iteratively explore at this period
                 # get indices of Lij that sort P


### PR DESCRIPTION
Hi, 

I tried to use the null_model_und_sign function to generate null-models, but it gave me the error:

`slice-indices-must-be-integers-or-none-or-have-index-method `

This error is related to the issue #68 

Then I looked at the code and found that the variable `wei_period` was rounded, but it remains as float, and it was used as a vector index, so I cast it to int and the function worked well.

Thanks for the amazing work here,
Murilo Schaefer