### PR TITLE
Duecredit integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ nosetests.xml
 
 # vim swap files
 *.swp
+
+.duecredit.p

--- a/CREDITS
+++ b/CREDITS
@@ -142,7 +142,7 @@ MODULARITY_FINETUNE
 (modularity_finetune_dir modularity_finetune_und modularity_finetune_und_sign
 modularity_probtune_und_sign)
 	Mika Rubinov			UNSW/Cambridge			2011/2013
-		Sun et al. (2008)  Europhysics Lett 86, 28004.
+		Sun et al. (2009)  Europhysics Lett 86, 28004.
 		Rubinov and Sporns (2011) NeuroImage.
 MODULARITY_LOUVAIN
 (modularity_louvain_dir modularity_louvain_und modularity_louvain_und_sign)

--- a/bct/__init__.py
+++ b/bct/__init__.py
@@ -8,5 +8,5 @@ from .due import due, BibTeX
 
 __citation__ = BCTPY
 
-due.cite(BibTeX(__citation__), description="Brain Connectivity Toolbox for Python", path="bctpy")
-due.cite(BibTeX(RUBINOV2010), description="Brain Connectivity Toolbox", path="bctpy")
+due.cite(BibTeX(__citation__), description="Brain Connectivity Toolbox for Python", path="bct")
+due.cite(BibTeX(RUBINOV2010), description="Brain Connectivity Toolbox", path="bct")

--- a/bct/__init__.py
+++ b/bct/__init__.py
@@ -1,6 +1,12 @@
-__version__ = '0.5.0'
-__version_info__ = tuple(int(i) for i in __version__.split('.'))
-
 from .algorithms import *
 from .utils import *
 from .nbs import *
+from .version import __version__, __version_info__
+from .citations import BCTPY, RUBINOV2010
+
+from .due import due, BibTeX
+
+__citation__ = BCTPY
+
+due.cite(BibTeX(__citation__), description="Brain Connectivity Toolbox for Python", path="bctpy")
+due.cite(BibTeX(RUBINOV2010), description="Brain Connectivity Toolbox", path="bctpy")

--- a/bct/algorithms/centrality.py
+++ b/bct/algorithms/centrality.py
@@ -3,8 +3,15 @@ import numpy as np
 from .core import kcore_bd, kcore_bu
 from .distance import reachdist
 from bct.utils import invert
+from ..due import due, BibTeX
+from ..citations import (
+    BRANDES2001, KINTALI2008, SHANNON1948, RUBINOV2011, NEWMAN2016, HONEY2007,
+    HAGMANN2008, GUIMERA2005, MORRISON2005, BOLDI2009, ESTRADA2005, ESTRADA2010
+)
 
 
+@due.dcite(BibTeX(BRANDES2001), description="Unweighted betweenness centrality")
+@due.dcite(BibTeX(KINTALI2008), description="Unweighted betweenness centrality")
 def betweenness_bin(G):
     '''
     Node betweenness centrality is the fraction of all shortest paths in
@@ -62,6 +69,8 @@ def betweenness_bin(G):
     return np.sum(DP, axis=0)
 
 
+@due.dcite(BibTeX(BRANDES2001), description="Weighted betweenness centrality")
+@due.dcite(BibTeX(KINTALI2008), description="Weighted betweenness centrality")
 def betweenness_wei(G):
     '''
     Node betweenness centrality is the fraction of all shortest paths in
@@ -137,6 +146,8 @@ def betweenness_wei(G):
     return BC
 
 
+@due.dcite(BibTeX(RUBINOV2011), description="Entropy-based diversity coefficient")
+@due.dcite(BibTeX(SHANNON1948), description="Entropy-based diversity coefficient")
 def diversity_coef_sign(W, ci):
     '''
     The Shannon-entropy based diversity coefficient measures the diversity
@@ -180,6 +191,8 @@ def diversity_coef_sign(W, ci):
 
     return Hpos, Hneg
 
+
+@due.dcite(BibTeX(BRANDES2001), description="Unweighted edge betweenness centrality")
 def edge_betweenness_bin(G):
     '''
     Edge betweenness centrality is the fraction of all shortest paths in
@@ -248,6 +261,7 @@ def edge_betweenness_bin(G):
     return EBC, BC
 
 
+@due.dcite(BibTeX(BRANDES2001), description="Weighted edge betweenness centrality")
 def edge_betweenness_wei(G):
     '''
     Edge betweenness centrality is the fraction of all shortest paths in
@@ -328,6 +342,7 @@ def edge_betweenness_wei(G):
     return EBC, BC
 
 
+@due.dcite(BibTeX(NEWMAN2016), description="Eigenvector centrality")
 def eigenvector_centrality_und(CIJ):
     '''
     Eigenector centrality is a self-referential measure of centrality:
@@ -402,6 +417,7 @@ def erange(CIJ):
     return Erange, eta, Eshort, fs
 
 
+@due.dcite(BibTeX(HONEY2007), description="Flow coefficient")
 def flow_coef_bd(CIJ):
     '''
     Computes the flow coefficient for each node and averaged over the
@@ -534,6 +550,7 @@ def gateway_coef_sign(W, ci, centrality_type='degree'):
     return G_pos, G_neg
 
 
+@due.dcite(BibTeX(HAGMANN2008), description="Unweighted directed k-coreness centrality")
 def kcoreness_centrality_bd(CIJ):
     '''
     The k-core is the largest subgraph comprising nodes of degree at least
@@ -566,6 +583,7 @@ def kcoreness_centrality_bd(CIJ):
     return coreness, kn
 
 
+@due.dcite(BibTeX(HAGMANN2008), description="Unweighted undirected k-coreness centrality")
 def kcoreness_centrality_bu(CIJ):
     '''
     The k-core is the largest subgraph comprising nodes of degree at least
@@ -603,6 +621,7 @@ def kcoreness_centrality_bu(CIJ):
     return coreness, kn
 
 
+@due.dcite(BibTeX(GUIMERA2005), description="Within-module degree z-score")
 def module_degree_zscore(W, ci, flag=0):
     '''
     The within-module degree z-score is a within-module version of degree
@@ -645,6 +664,8 @@ def module_degree_zscore(W, ci, flag=0):
     return Z
 
 
+@due.dcite(BibTeX(MORRISON2005), description="PageRank centrality")
+@due.dcite(BibTeX(BOLDI2009), description="PageRank centrality")
 def pagerank_centrality(A, d, falff=None):
     '''
     The PageRank centrality is a variant of eigenvector centrality. This
@@ -700,6 +721,7 @@ def pagerank_centrality(A, d, falff=None):
     return r
 
 
+@due.dcite(BibTeX(GUIMERA2005), description="Participation coefficient")
 def participation_coef(W, ci, degree='undirected'):
     '''
     Participation coefficient is a measure of diversity of intermodular
@@ -827,6 +849,9 @@ def participation_coef_sign(W, ci):
 
     return Ppos, Pneg
 
+
+@due.dcite(BibTeX(ESTRADA2005), description="Subgraph centrality")
+@due.dcite(BibTeX(ESTRADA2010), description="Subgraph centrality")
 def subgraph_centrality(CIJ):
     '''
     The subgraph centrality of a node is a weighted sum of closed walks of

--- a/bct/algorithms/clustering.py
+++ b/bct/algorithms/clustering.py
@@ -3,6 +3,11 @@ import numpy as np
 from .modularity import modularity_louvain_und_sign
 from bct.utils import cuberoot, BCTParamError, dummyvar, binarize, get_rng
 from .distance import breadthdist
+from ..due import due, BibTeX
+from ..citations import (
+    WATTS1998, ONNELA2005, FAGIOLO2007, LANCICHINETTI2012,
+    RUBINOV2010, HUMPHRIES2008, COSTANTINI2014, ZHANG2005
+)
 
 
 def agreement(ci, buffsz=1000):
@@ -89,6 +94,9 @@ def agreement_weighted(ci, wts):
     return D
 
 
+@due.dcite(BibTeX(WATTS1998), description="Unweighted directed clustering coefficient")
+@due.dcite(BibTeX(ONNELA2005), description="Unweighted directed clustering coefficient")
+@due.dcite(BibTeX(FAGIOLO2007), description="Unweighted directed clustering coefficient")
 def clustering_coef_bd(A):
     '''
     The clustering coefficient is the fraction of triangles around a node
@@ -127,6 +135,9 @@ def clustering_coef_bd(A):
     return C
 
 
+@due.dcite(BibTeX(WATTS1998), description="Unweighted undirected clustering coefficient")
+@due.dcite(BibTeX(ONNELA2005), description="Unweighted undirected clustering coefficient")
+@due.dcite(BibTeX(FAGIOLO2007), description="Unweighted undirected clustering coefficient")
 def clustering_coef_bu(G):
     '''
     The clustering coefficient is the fraction of triangles around a node
@@ -155,6 +166,9 @@ def clustering_coef_bu(G):
     return C
 
 
+@due.dcite(BibTeX(WATTS1998), description="Weighted directed clustering coefficient")
+@due.dcite(BibTeX(ONNELA2005), description="Weighted directed clustering coefficient")
+@due.dcite(BibTeX(FAGIOLO2007), description="Weighted directed clustering coefficient")
 def clustering_coef_wd(W):
     '''
     The weighted clustering coefficient is the average "intensity" of
@@ -191,6 +205,9 @@ def clustering_coef_wd(W):
     return C
 
 
+@due.dcite(BibTeX(WATTS1998), description="Weighted undirected clustering coefficient")
+@due.dcite(BibTeX(ONNELA2005), description="Weighted undirected clustering coefficient")
+@due.dcite(BibTeX(FAGIOLO2007), description="Weighted undirected clustering coefficient")
 def clustering_coef_wu(W):
     '''
     The weighted clustering coefficient is the average "intensity" of
@@ -214,6 +231,21 @@ def clustering_coef_wu(W):
     return C
 
 
+@due.dcite(
+    BibTeX(ONNELA2005),
+    description="Weighted undirected signed clustering coefficient (Onnela)",
+    conditions={(1, "coef_type"): {"DC_DEFAULT", "default"}}
+)
+@due.dcite(
+    BibTeX(COSTANTINI2014),
+    description="Weighted undirected signed clustering coefficient (Costatini)",
+    conditions={(1, "coef_type"): {"costantini"}}
+)
+@due.dcite(
+    BibTeX(ZHANG2005),
+    description="Weighted undirected signed clustering coefficient (Zhang)",
+    conditions={(1, "coef_type"): {"zhang"}}
+)
 def clustering_coef_wu_sign(W, coef_type='default'):
     '''
     Returns the weighted clustering coefficient generalized or separated
@@ -316,6 +348,8 @@ def clustering_coef_wu_sign(W, coef_type='default'):
         C = cyc3 / cyc2
         return C
 
+
+@due.dcite(BibTeX(LANCICHINETTI2012), description="Undirected consensus partitioning")
 def consensus_und(D, tau, reps=1000, seed=None):
     '''
     This algorithm seeks a consensus partition of the
@@ -562,6 +596,10 @@ def number_of_components(A):
     return len(csizes)
 
 
+@due.dcite(BibTeX(RUBINOV2010), description="Transitivity, unweighted directed")
+@due.dcite(BibTeX(ONNELA2005), description="Transitivity, unweighted directed")
+@due.dcite(BibTeX(FAGIOLO2007), description="Transitivity, unweighted directed")
+@due.dcite(BibTeX(HUMPHRIES2008), description="Transitivity, unweighted directed")
 def transitivity_bd(A):
     '''
     Transitivity is the ratio of 'triangles to triplets' in the network.
@@ -597,6 +635,10 @@ def transitivity_bd(A):
     return np.sum(cyc3) / np.sum(CYC3)
 
 
+@due.dcite(BibTeX(RUBINOV2010), description="Transitivity, unweighted undirected")
+@due.dcite(BibTeX(ONNELA2005), description="Transitivity, unweighted undirected")
+@due.dcite(BibTeX(FAGIOLO2007), description="Transitivity, unweighted undirected")
+@due.dcite(BibTeX(HUMPHRIES2008), description="Transitivity, unweighted undirected")
 def transitivity_bu(A):
     '''
     Transitivity is the ratio of 'triangles to triplets' in the network.
@@ -617,6 +659,10 @@ def transitivity_bu(A):
     return tri3 / tri2
 
 
+@due.dcite(BibTeX(RUBINOV2010), description="Transitivity, weighted directed")
+@due.dcite(BibTeX(ONNELA2005), description="Transitivity, weighted directed")
+@due.dcite(BibTeX(FAGIOLO2007), description="Transitivity, weighted directed")
+@due.dcite(BibTeX(HUMPHRIES2008), description="Transitivity, weighted directed")
 def transitivity_wd(W):
     '''
     Transitivity is the ratio of 'triangles to triplets' in the network.
@@ -650,6 +696,10 @@ def transitivity_wd(W):
     return np.sum(cyc3) / np.sum(CYC3)  # transitivity
 
 
+@due.dcite(BibTeX(RUBINOV2010), description="Transitivity, weighted undirected")
+@due.dcite(BibTeX(ONNELA2005), description="Transitivity, weighted undirected")
+@due.dcite(BibTeX(FAGIOLO2007), description="Transitivity, weighted undirected")
+@due.dcite(BibTeX(HUMPHRIES2008), description="Transitivity, weighted undirected")
 def transitivity_wu(W):
     '''
     Transitivity is the ratio of 'triangles to triplets' in the network.

--- a/bct/algorithms/core.py
+++ b/bct/algorithms/core.py
@@ -5,7 +5,12 @@ from ..utils.miscellaneous_utilities import get_rng, BCTParamError
 from .degree import degrees_dir, degrees_und, strengths_dir, strengths_und
 from .degree import strengths_und_sign
 
+from ..due import due, BibTeX
+from ..citations import NEWMAN2002, FOSTER2010, HAGMANN2008, COLIZZA2006, OPSAHL2008, HEUVEL2011
 
+
+@due.dcite(BibTeX(NEWMAN2002), description="Unweighted assortativity coefficient")
+@due.dcite(BibTeX(FOSTER2010), description="Unweighted assortativity coefficient")
 def assortativity_bin(CIJ, flag=0):
     '''
     The assortativity coefficient is a correlation coefficient between the
@@ -70,6 +75,8 @@ def assortativity_bin(CIJ, flag=0):
     return r
 
 
+@due.dcite(BibTeX(NEWMAN2002), description="Unweighted assortativity coefficient")
+@due.dcite(BibTeX(FOSTER2010), description="Unweighted assortativity coefficient")
 def assortativity_wei(CIJ, flag=0):
     '''
     The assortativity coefficient is a correlation coefficient between the
@@ -229,6 +236,7 @@ def core_periphery_dir(W, gamma=1, C0=None, seed=None):
     return C, q
 
 
+@due.dcite(BibTeX(HAGMANN2008), description="Unweighted directed k-core")
 def kcore_bd(CIJ, k, peel=False):
     '''
     The k-core is the largest subnetwork comprising nodes of degree at
@@ -297,6 +305,7 @@ def kcore_bd(CIJ, k, peel=False):
         return CIJkcore, kn
 
 
+@due.dcite(BibTeX(HAGMANN2008), description="Unweighted undirected k-core")
 def kcore_bu(CIJ, k, peel=False):
     '''
     The k-core is the largest subnetwork comprising nodes of degree at
@@ -409,6 +418,10 @@ def local_assortativity_wu_sign(W):
 
     return loc_assort_pos, loc_assort_neg
 
+
+@due.dcite(BibTeX(COLIZZA2006), description="Rich club; binary, directed")
+@due.dcite(BibTeX(OPSAHL2008), description="Rich club; binary, directed")
+@due.dcite(BibTeX(HEUVEL2011), description="Rich club; binary, directed")
 def rich_club_bd(CIJ, klevel=None):
     '''
     The rich club coefficient, R, at level k is the fraction of edges that
@@ -455,6 +468,9 @@ def rich_club_bd(CIJ, klevel=None):
     return R, Nk, Ek
 
 
+@due.dcite(BibTeX(COLIZZA2006), description="Rich club; binary, undirected")
+@due.dcite(BibTeX(OPSAHL2008), description="Rich club; binary, undirected")
+@due.dcite(BibTeX(HEUVEL2011), description="Rich club; binary, undirected")
 def rich_club_bu(CIJ, klevel=None):
     '''
     The rich club coefficient, R, at level k is the fraction of edges that
@@ -499,6 +515,9 @@ def rich_club_bu(CIJ, klevel=None):
     return R, Nk, Ek
 
 
+@due.dcite(BibTeX(COLIZZA2006), description="Rich club; weighted, directed")
+@due.dcite(BibTeX(OPSAHL2008), description="Rich club; weighted, directed")
+@due.dcite(BibTeX(HEUVEL2011), description="Rich club; weighted, directed")
 def rich_club_wd(CIJ, klevel=None):
     '''
     Parameters
@@ -546,6 +565,9 @@ def rich_club_wd(CIJ, klevel=None):
     return Rw
 
 
+@due.dcite(BibTeX(COLIZZA2006), description="Rich club; weighted, undirected")
+@due.dcite(BibTeX(OPSAHL2008), description="Rich club; weighted, undirected")
+@due.dcite(BibTeX(HEUVEL2011), description="Rich club; weighted, undirected")
 def rich_club_wu(CIJ, klevel=None):
     '''
     Parameters

--- a/bct/algorithms/distance.py
+++ b/bct/algorithms/distance.py
@@ -1,6 +1,8 @@
 from __future__ import division, print_function
 import numpy as np
 from bct.utils import cuberoot, binarize, invert
+from ..due import due, BibTeX
+from ..citations import LATORA2001, ONNELA2005, FAGIOLO2007, RUBINOV2010
 
 
 def breadthdist(CIJ):
@@ -466,6 +468,10 @@ def retrieve_shortest_path(s, t, hops, Pmat):
     return path
 
 
+@due.dcite(BibTeX(LATORA2001), description="Unweighted global efficiency")
+@due.dcite(BibTeX(ONNELA2005), description="Unweighted global efficiency")
+@due.dcite(BibTeX(FAGIOLO2007), description="Unweighted global efficiency")
+@due.dcite(BibTeX(RUBINOV2010), description="Unweighted global efficiency")
 def efficiency_bin(G, local=False):
     '''
     The global efficiency is the average of inverse shortest path length,
@@ -537,6 +543,10 @@ def efficiency_bin(G, local=False):
     return E
 
 
+@due.dcite(BibTeX(LATORA2001), description="Weighted global efficiency")
+@due.dcite(BibTeX(ONNELA2005), description="Weighted global efficiency")
+@due.dcite(BibTeX(FAGIOLO2007), description="Weighted global efficiency")
+@due.dcite(BibTeX(RUBINOV2010), description="Weighted global efficiency")
 def efficiency_wei(Gw, local=False):
     '''
     The global efficiency is the average of inverse shortest path length,

--- a/bct/algorithms/generative.py
+++ b/bct/algorithms/generative.py
@@ -5,8 +5,11 @@ from bct.utils import BCTParamError, get_rng
 from .similarity import matching_ind
 from .clustering import clustering_coef_bu
 from .centrality import betweenness_bin
+from ..due import due, BibTeX
+from ..citations import BETZEL2016
 
 
+@due.dcite(BibTeX(BETZEL2016), description="Generative models")
 def generative_model(A, D, m, eta, gamma=None, model_type='matching', 
     model_var='powerlaw', epsilon=1e-6, copy=True, seed=None):
     '''

--- a/bct/algorithms/modularity.py
+++ b/bct/algorithms/modularity.py
@@ -1,6 +1,11 @@
 from __future__ import division, print_function
 import numpy as np
 from bct.utils import BCTParamError, normalize, get_rng
+from ..due import BibTeX, due
+from ..citations import (
+    LEICHT2008, REICHARDT2006, GOOD2010, SUN2008, RUBINOV2011,
+    BLONDEL2008, MEILA2007
+)
 
 
 def ci2ls(ci):
@@ -474,6 +479,9 @@ def _safe_squeeze(arr, *args, **kwargs):
     return out
 
 
+@due.dcite(BibTeX(LEICHT2008), description="Directed modularity")
+@due.dcite(BibTeX(REICHARDT2006), description="Directed modularity")
+@due.dcite(BibTeX(GOOD2010), description="Directed modularity")
 def modularity_dir(A, gamma=1, kci=None):
     '''
     The optimal community structure is a subdivision of the network into
@@ -576,6 +584,8 @@ def modularity_dir(A, gamma=1, kci=None):
     return ci, q
 
 
+@due.dcite(BibTeX(SUN2008), description="Finetuned directed modularity")
+@due.dcite(BibTeX(RUBINOV2011), description="Finetuned directed modularity")
 def modularity_finetune_dir(W, ci=None, gamma=1, seed=None):
     '''
     The optimal community structure is a subdivision of the network into
@@ -678,6 +688,8 @@ def modularity_finetune_dir(W, ci=None, gamma=1, seed=None):
     return ci, q
 
 
+@due.dcite(BibTeX(SUN2008), description="Finetuned undirected modularity")
+@due.dcite(BibTeX(RUBINOV2011), description="Finetuned undirected modularity")
 def modularity_finetune_und(W, ci=None, gamma=1, seed=None):
     '''
     The optimal community structure is a subdivision of the network into
@@ -776,6 +788,8 @@ def modularity_finetune_und(W, ci=None, gamma=1, seed=None):
     return ci, q
 
 
+@due.dcite(BibTeX(SUN2008), description="Finetuned directed signed modularity")
+@due.dcite(BibTeX(RUBINOV2011), description="Finetuned directed signed modularity")
 def modularity_finetune_und_sign(W, qtype='sta', gamma=1, ci=None, seed=None):
     '''
     The optimal community structure is a subdivision of the network into
@@ -910,6 +924,9 @@ def modularity_finetune_und_sign(W, qtype='sta', gamma=1, ci=None, seed=None):
     return ci, q
 
 
+@due.dcite(BibTeX(BLONDEL2008), description="Louvain directed modularity")
+@due.dcite(BibTeX(REICHARDT2006), description="Louvain directed modularity")
+@due.dcite(BibTeX(RUBINOV2011), description="Louvain directed modularity")
 def modularity_louvain_dir(W, gamma=1, hierarchy=False, seed=None):
     '''
     The optimal community structure is a subdivision of the network into
@@ -1040,6 +1057,9 @@ def modularity_louvain_dir(W, gamma=1, hierarchy=False, seed=None):
         return ci[h - 1], q[h - 1]
 
 
+@due.dcite(BibTeX(BLONDEL2008), description="Louvain undirected modularity")
+@due.dcite(BibTeX(REICHARDT2006), description="Louvain undirected modularity")
+@due.dcite(BibTeX(RUBINOV2011), description="Louvain undirected modularity")
 def modularity_louvain_und(W, gamma=1, hierarchy=False, seed=None):
     '''
     The optimal community structure is a subdivision of the network into
@@ -1171,6 +1191,9 @@ def modularity_louvain_und(W, gamma=1, hierarchy=False, seed=None):
         return ci[h - 1], q[h - 1]
 
 
+@due.dcite(BibTeX(BLONDEL2008), description="Louvain undirected signed modularity")
+@due.dcite(BibTeX(REICHARDT2006), description="Louvain undirected signed modularity")
+@due.dcite(BibTeX(RUBINOV2011), description="Louvain undirected signed modularity")
 def modularity_louvain_und_sign(W, gamma=1, qtype='sta', seed=None):
     '''
     The optimal community structure is a subdivision of the network into
@@ -1335,6 +1358,8 @@ def modularity_louvain_und_sign(W, gamma=1, qtype='sta', seed=None):
     return ci_ret, q[-1]
 
 
+@due.dcite(BibTeX(SUN2008), description="Probabilistic finetuned undirected modularity")
+@due.dcite(BibTeX(RUBINOV2011), description="Probabilistic finetuned undirected modularity")
 def modularity_probtune_und_sign(W, qtype='sta', gamma=1, ci=None, p=.45,
                                  seed=None):
     '''
@@ -1470,6 +1495,9 @@ def modularity_probtune_und_sign(W, qtype='sta', gamma=1, ci=None, p=.45,
     return ci, q
 
 
+@due.dcite(BibTeX(LEICHT2008), description="Undirected modularity")
+@due.dcite(BibTeX(REICHARDT2006), description="Undirected modularity")
+@due.dcite(BibTeX(GOOD2010), description="Undirected modularity")
 def modularity_und(A, gamma=1, kci=None):
     '''
     The optimal community structure is a subdivision of the network into
@@ -1653,6 +1681,7 @@ def modularity_und_sign(W, ci, qtype='sta'):
     return ci, q
 
 
+@due.dcite(BibTeX(MEILA2007), description="Partition distance")
 def partition_distance(cx, cy):
     '''
     This function quantifies the distance between pairs of community

--- a/bct/algorithms/motifs.py
+++ b/bct/algorithms/motifs.py
@@ -1,12 +1,15 @@
 from __future__ import division, print_function
 import numpy as np
 from bct.utils import BCTParamError, binarize
+from ..citations import ONNELA2005
+from ..due import BibTeX, due
 
 motiflib = 'motif34lib.mat'
 
 # FIXME there may be some subtle bugs here
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Motif isomorphs")
 def find_motif34(m, n=None):
     '''
     This function returns all motif isomorphs for a given motif id and
@@ -178,6 +181,7 @@ def make_motif34lib():
                              'm4': m4, 'm4n': m4n, 'id4': id4, 'n4': n4})
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Functional motif frequencies")
 def motif3funct_bin(A):
     '''
     Functional motifs are subsets of connection patterns embedded within
@@ -247,6 +251,7 @@ def motif3funct_bin(A):
     return f, F
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Functional motif intensity, coherence, frequency")
 def motif3funct_wei(W):
     '''
     Functional motifs are subsets of connection patterns embedded within
@@ -341,6 +346,7 @@ def motif3funct_wei(W):
     return I, Q, F
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Structural motif frequency")
 def motif3struct_bin(A):
     '''
     Structural motifs are patterns of local connectivity. Motif frequency
@@ -395,6 +401,7 @@ def motif3struct_bin(A):
     return f, F
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Structural motif intensity, coherence, frequency")
 def motif3struct_wei(W):
     '''
     Structural motifs are patterns of local connectivity. Motif frequency
@@ -477,6 +484,7 @@ def motif3struct_wei(W):
     return I, Q, F
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Unweighted functional motif frequency")
 def motif4funct_bin(A):
     '''
     Functional motifs are subsets of connection patterns embedded within
@@ -558,6 +566,7 @@ def motif4funct_bin(A):
     return f, F
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Weighted functional motif intensity, coherence, frequency")
 def motif4funct_wei(W):
     '''
     Functional motifs are subsets of connection patterns embedded within
@@ -670,6 +679,7 @@ def motif4funct_wei(W):
     return I, Q, F
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Unweighted structural motif frequency")
 def motif4struct_bin(A):
     '''
     Structural motifs are patterns of local connectivity. Motif frequency
@@ -741,6 +751,7 @@ def motif4struct_bin(A):
     return f, F
 
 
+@due.dcite(BibTeX(ONNELA2005), description="Weighted structural motif intensity, coherence, frequency")
 def motif4struct_wei(W):
     '''
     Structural motifs are patterns of local connectivity. Motif frequency

--- a/bct/algorithms/reference.py
+++ b/bct/algorithms/reference.py
@@ -3,8 +3,12 @@ import numpy as np
 from bct.utils import BCTParamError, binarize, get_rng
 from bct.utils import pick_four_unique_nodes_quickly
 from .clustering import number_of_components
+from ..citations import MASLOV2002, SPORNS2004, RUBINOV2011
+from ..due import BibTeX, due
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Latticize directed connected network")
+@due.dcite(BibTeX(SPORNS2004), description="Latticize directed connected network")
 def latmio_dir_connected(R, itr, D=None, seed=None):
     '''
     This function "latticizes" a directed network, while preserving the in-
@@ -128,6 +132,8 @@ def latmio_dir_connected(R, itr, D=None, seed=None):
     return Rlatt, R, ind_rp, eff
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Latticize directed network")
+@due.dcite(BibTeX(SPORNS2004), description="Latticize directed network")
 def latmio_dir(R, itr, D=None, seed=None):
     '''
     This function "latticizes" a directed network, while preserving the in-
@@ -223,6 +229,8 @@ def latmio_dir(R, itr, D=None, seed=None):
     return Rlatt, R, ind_rp, eff
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Latticize undirected connected network")
+@due.dcite(BibTeX(SPORNS2004), description="Latticize undirected connected network")
 def latmio_und_connected(R, itr, D=None, seed=None):
     '''
     This function "latticizes" an undirected network, while preserving the
@@ -359,6 +367,8 @@ def latmio_und_connected(R, itr, D=None, seed=None):
     return Rlatt, R, ind_rp, eff
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Latticize undirected network")
+@due.dcite(BibTeX(SPORNS2004), description="Latticize undirected network")
 def latmio_und(R, itr, D=None, seed=None):
     '''
     This function "latticizes" an undirected network, while preserving the
@@ -851,6 +861,7 @@ def maketoeplitzCIJ(n, k, s, seed=None):
     return CIJ
 
 
+@due.dcite(BibTeX(RUBINOV2011), description="Directed signed null model")
 def null_model_dir_sign(W, bin_swaps=5, wei_freq=.1, seed=None):
     '''
     This function randomizes an directed network with positive and
@@ -973,6 +984,7 @@ def null_model_dir_sign(W, bin_swaps=5, wei_freq=.1, seed=None):
     return W0, (rpos_in[0, 1], rpos_ou[0, 1], rneg_in[0, 1], rneg_ou[0, 1])
 
 
+@due.dcite(BibTeX(RUBINOV2011), description="Undirected signed null model")
 def null_model_und_sign(W, bin_swaps=5, wei_freq=.1, seed=None):
     '''
     This function randomizes an undirected network with positive and
@@ -1102,6 +1114,7 @@ def null_model_und_sign(W, bin_swaps=5, wei_freq=.1, seed=None):
     return W0, (rpos_in[0, 1], rpos_ou[0, 1], rneg_in[0, 1], rneg_ou[0, 1])
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Randomisation, directed and connected")
 def randmio_dir_connected(R, itr, seed=None):
     '''
     This function randomizes a directed network, while preserving the in-
@@ -1196,6 +1209,7 @@ def randmio_dir_connected(R, itr, seed=None):
     return R, eff
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Randomisation, directed")
 def randmio_dir(R, itr, seed=None):
     '''
     This function randomizes a directed network, while preserving the in-
@@ -1263,6 +1277,7 @@ def randmio_dir(R, itr, seed=None):
     return R, eff
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Randomisation, undirected and connected")
 def randmio_und_connected(R, itr, seed=None):
     '''
     This function randomizes an undirected network, while preserving the
@@ -1381,6 +1396,7 @@ def randmio_und_connected(R, itr, seed=None):
     return R, eff
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Randomisation, directed and signed")
 def randmio_dir_signed(R, itr, seed=None):
     '''
     This function randomizes a directed weighted network with positively
@@ -1457,6 +1473,8 @@ def randmio_dir_signed(R, itr, seed=None):
 
     return R, eff
 
+
+@due.dcite(BibTeX(MASLOV2002), description="Randomisation, undirected")
 def randmio_und(R, itr, seed=None):
     '''
     This function randomizes an undirected network, while preserving the
@@ -1538,6 +1556,7 @@ def randmio_und(R, itr, seed=None):
     return R, eff
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Randomisation, undirected and signed")
 def randmio_und_signed(R, itr, seed=None):
     '''
     This function randomizes an undirected weighted network with positive
@@ -1597,6 +1616,7 @@ def randmio_und_signed(R, itr, seed=None):
             att += 1
 
     return R, eff
+
 
 def randomize_graph_partial_und(A, B, maxswap, seed=None):
     '''
@@ -1674,6 +1694,7 @@ def randomize_graph_partial_und(A, B, maxswap, seed=None):
     return A
 
 
+@due.dcite(BibTeX(MASLOV2002), description="Randomize binary undirected")
 def randomizer_bin_und(R, alpha, seed=None):
     '''
     This function randomizes a binary undirected network, while preserving

--- a/bct/algorithms/similarity.py
+++ b/bct/algorithms/similarity.py
@@ -2,6 +2,8 @@ from __future__ import division, print_function
 import numpy as np
 from bct.utils import BCTParamError, binarize
 from .degree import degrees_dir, degrees_und
+from ..due import BibTeX, due
+from ..citations import YIP2007, RAVASZ2002
 
 
 def edge_nei_overlap_bd(CIJ):
@@ -100,6 +102,8 @@ def edge_nei_overlap_bu(CIJ):
     return EC, ec, degij
 
 
+@due.dcite(BibTeX(YIP2007), description="Generalized topological overlap measure")
+@due.dcite(BibTeX(RAVASZ2002), description="Generalized topological overlap measure")
 def gtom(adj, nr_steps):
     '''
     The m-th step generalized topological overlap measure (GTOM) quantifies

--- a/bct/citations.py
+++ b/bct/citations.py
@@ -1,18 +1,18 @@
+from __future__ import unicode_literals
 from .version import __version__
+from datetime import datetime
 
 BCTPY = """
 @misc{{{{bctpy,
     publisher = {{GitHub}},
-    title = {{bctpy v{}}},
+    title = {{bctpy v{version}}},
     url = {{https://github.com/aestrivex/bctpy}},
     author = {{Roan LaPlante}},
-    note = {{[Online; accessed 2019-07-23]}},
-    date = {{2018-12-23}},
-    year = {{2018}},
-    month = {{12}},
-    day = {{23}},
+    note = {{[Online; accessed {datestamp}]}},
 }}
-""".format(__version__).strip()
+""".format(
+    version=__version__, datestamp=datetime.utcnow().strftime("%Y-%m-%d")
+).strip()
 
 NEWMAN2002 = """
 @article{newman2002spread,
@@ -95,7 +95,7 @@ KINTALI2008 = """
 
 WATTS1998 = """
 @article{watts1998collective,
-  title={Collective dynamics of ‘small-world’networks},
+  title={Collective dynamics of `small-world' networks},
   author={Watts, Duncan J and Strogatz, Steven H},
   journal={nature},
   volume={393},
@@ -492,7 +492,7 @@ ESTRADA2010 = """
 
 HUMPHRIES2008 = """
 @article{humphries2008network,
-  title={Network ‘small-world-ness’: a quantitative method for determining canonical network equivalence},
+  title={Network `small-world-ness': a quantitative method for determining canonical network equivalence},
   author={Humphries, Mark D and Gurney, Kevin},
   journal={PloS one},
   volume={3},

--- a/bct/citations.py
+++ b/bct/citations.py
@@ -3,11 +3,11 @@ from .version import __version__
 from datetime import datetime
 
 BCTPY = """
-@misc{{{{bctpy,
+@misc{{bctpy,
     publisher = {{GitHub}},
-    title = {{bctpy v{version}}},
+    title = {{bctpy v{version}: Brain Connectivity Toolbox for Python}},
     url = {{https://github.com/aestrivex/bctpy}},
-    author = {{Roan LaPlante}},
+    author = {{LaPlante, Roan and others}},
     note = {{[Online; accessed {datestamp}]}},
 }}
 """.format(
@@ -527,3 +527,16 @@ COSTANTINI2014 = """
   publisher={Public Library of Science}
 }
 """.strip()
+
+BETZEL2016 = """
+@article{betzel2016generative,
+  title={Generative models of the human connectome},
+  author={Betzel, Richard F and Avena-Koenigsberger, Andrea and Go{\\~n}i, Joaqu{\\'\\i}n and He, Ye and De Reus, Marcel A and Griffa, Alessandra and V{\\'e}rtes, Petra E and Mi{\\v{s}}ic, Bratislav and Thiran, Jean-Philippe and Hagmann, Patric and others},
+  journal={Neuroimage},
+  volume={124},
+  pages={1054--1064},
+  year={2016},
+  publisher={Elsevier}
+}
+""".strip()
+

--- a/bct/citations.py
+++ b/bct/citations.py
@@ -1,0 +1,491 @@
+from .version import __version__
+
+BCTPY = """
+@misc{{{{bctpy,
+    publisher = {{GitHub}},
+    title = {{bctpy v{}}},
+    url = {{https://github.com/aestrivex/bctpy}},
+    author = {{Roan LaPlante}},
+    note = {{[Online; accessed 2019-07-23]}},
+    date = {{2018-12-23}},
+    year = {{2018}},
+    month = {{12}},
+    day = {{23}},
+}}
+""".format(__version__).strip()
+
+NEWMAN2002 = """
+@article{newman2002spread,
+  title = {Spread of epidemic disease on networks},
+  author = {Newman, M. E. J.},
+  journal = {Phys. Rev. E},
+  volume = {66},
+  issue = {1},
+  pages = {016128},
+  numpages = {11},
+  year = {2002},
+  month = {Jul},
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevE.66.016128},
+  url = {https://link.aps.org/doi/10.1103/PhysRevE.66.016128}
+}
+""".strip()
+
+FOSTER2010 = """
+@article{foster2010edge,
+  title={Edge direction and the structure of networks},
+  author={Foster, Jacob G and Foster, David V and Grassberger, Peter and Paczuski, Maya},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={107},
+  number={24},
+  pages={10815--10820},
+  year={2010},
+  publisher={National Acad Sciences}
+}
+""".strip()
+
+HIDALGO2007 = """
+@article{hidalgo2007product,
+  title={The product space conditions the development of nations},
+  author={Hidalgo, C{\\'e}sar A and Klinger, Bailey and Barab{\\'a}si, A-L and Hausmann, Ricardo},
+  journal={Science},
+  volume={317},
+  number={5837},
+  pages={482--487},
+  year={2007},
+  publisher={American Association for the Advancement of Science}
+}
+""".strip()
+
+HAGMANN2008 = """
+@article{hagmann2008mapping,
+  title={Mapping the structural core of human cerebral cortex},
+  author={Hagmann, Patric and Cammoun, Leila and Gigandet, Xavier and Meuli, Reto and Honey, Christopher J and Wedeen, Van J and Sporns, Olaf},
+  journal={PLoS biology},
+  volume={6},
+  number={7},
+  pages={e159},
+  year={2008},
+  publisher={Public Library of Science}
+}
+
+""".strip()
+
+BRANDES2001 = """
+@article{brandes2008variants,
+  title={On variants of shortest-path betweenness centrality and their generic computation},
+  author={Brandes, Ulrik},
+  journal={Social Networks},
+  volume={30},
+  number={2},
+  pages={136--145},
+  year={2008},
+  publisher={Elsevier}
+}
+""".strip()
+
+KINTALI2008 = """
+@article{kintali2008betweenness,
+  title={Betweenness centrality: Algorithms and lower bounds},
+  author={Kintali, Shiva},
+  journal={arXiv preprint arXiv:0809.1906},
+  year={2008}
+}
+""".strip()
+
+WATTS1998 = """
+@article{watts1998collective,
+  title={Collective dynamics of ‘small-world’networks},
+  author={Watts, Duncan J and Strogatz, Steven H},
+  journal={nature},
+  volume={393},
+  number={6684},
+  pages={440},
+  year={1998},
+  publisher={Nature Publishing Group}
+}
+""".strip()
+
+ONNELA2005 = """
+@article{onnela2005intensity,
+  title={Intensity and coherence of motifs in weighted complex networks},
+  author={Onnela, Jukka-Pekka and Saram{\\"a}ki, Jari and Kert{\\'e}sz, J{\\'a}nos and Kaski, Kimmo},
+  journal={Physical Review E},
+  volume={71},
+  number={6},
+  pages={065103},
+  year={2005},
+  publisher={APS}
+}
+""".strip()
+
+FAGIOLO2007 = """
+@article{fagiolo2007clustering,
+  title={Clustering in complex directed networks},
+  author={Fagiolo, Giorgio},
+  journal={Physical Review E},
+  volume={76},
+  number={2},
+  pages={026107},
+  year={2007},
+  publisher={APS}
+}
+""".strip()
+
+LANCICHINETTI2012 = """
+@article{lancichinetti2012consensus,
+  title={Consensus clustering in complex networks},
+  author={Lancichinetti, Andrea and Fortunato, Santo},
+  journal={Scientific reports},
+  volume={2},
+  pages={336},
+  year={2012},
+  publisher={Nature Publishing Group}
+}
+""".strip()
+
+SHANNON1948 = """
+@article{shannon1948mathematical,
+  title={A mathematical theory of communication},
+  author={Shannon, Claude Elwood},
+  journal={Bell system technical journal},
+  volume={27},
+  number={3},
+  pages={379--423},
+  year={1948},
+  publisher={Wiley Online Library}
+}
+""".strip()
+
+RUBINOV2011 = """
+@article{rubinov2011weight,
+  title={Weight-conserving characterization of complex functional brain networks},
+  author={Rubinov, Mikail and Sporns, Olaf},
+  journal={Neuroimage},
+  volume={56},
+  number={4},
+  pages={2068--2079},
+  year={2011},
+  publisher={Elsevier}
+}
+""".strip()
+
+EASLY2010 = """
+@book{easley2010networks,
+  title={Networks, crowds, and markets},
+  author={Easley, David and Kleinberg, Jon and others},
+  volume={8},
+  year={2010},
+  publisher={Cambridge university press Cambridge}
+}
+""".strip()
+
+LATORA2001 = """
+@article{latora2001efficient,
+  title={Efficient behavior of small-world networks},
+  author={Latora, Vito and Marchiori, Massimo},
+  journal={Physical review letters},
+  volume={87},
+  number={19},
+  pages={198701},
+  year={2001},
+  publisher={APS}
+}
+""".strip()
+
+RUBINOV2010 = """
+@article{rubinov2010complex,
+  title={Complex network measures of brain connectivity: uses and interpretations},
+  author={Rubinov, Mikail and Sporns, Olaf},
+  journal={Neuroimage},
+  volume={52},
+  number={3},
+  pages={1059--1069},
+  year={2010},
+  publisher={Elsevier}
+}
+""".strip()
+
+NEWMAN2016 = """
+@article{newman2016mathematics,
+  title={Mathematics of networks},
+  author={Newman, Mark EJ},
+  journal={The new Palgrave dictionary of economics},
+  pages={1--8},
+  year={2016},
+  publisher={Springer}
+}
+""".strip()
+
+YIP2007 = """
+@article{yip2007gene,
+  title={Gene network interconnectedness and the generalized topological overlap measure},
+  author={Yip, Andy M and Horvath, Steve},
+  journal={BMC bioinformatics},
+  volume={8},
+  number={1},
+  pages={22},
+  year={2007},
+  publisher={BioMed Central}
+}
+""".strip()
+
+RAVASZ2002 = """
+@article{ravasz2002hierarchical,
+  title={Hierarchical organization of modularity in metabolic networks},
+  author={Ravasz, Erzs{\\'e}bet and Somera, Anna Lisa and Mongru, Dale A and Oltvai, Zolt{\\'a}n N and Barab{\\'a}si, A-L},
+  journal={science},
+  volume={297},
+  number={5586},
+  pages={1551--1555},
+  year={2002},
+  publisher={American Association for the Advancement of Science}
+}
+""".strip()
+
+MASLOV2002 = """
+@article{maslov2002specificity,
+  title={Specificity and stability in topology of protein networks},
+  author={Maslov, Sergei and Sneppen, Kim},
+  journal={Science},
+  volume={296},
+  number={5569},
+  pages={910--913},
+  year={2002},
+  publisher={American Association for the Advancement of Science}
+}
+""".strip()
+
+SPOONS2004 = """
+@article{sporns2004small,
+  title={The small world of the cerebral cortex},
+  author={Sporns, Olaf and Zwi, Jonathan D},
+  journal={Neuroinformatics},
+  volume={2},
+  number={2},
+  pages={145--162},
+  year={2004},
+  publisher={Springer}
+}
+""".strip()
+
+LEICHT2008 = """
+@article{leicht2008community,
+  title={Community structure in directed networks},
+  author={Leicht, Elizabeth A and Newman, Mark EJ},
+  journal={Physical review letters},
+  volume={100},
+  number={11},
+  pages={118703},
+  year={2008},
+  publisher={APS}
+}
+""".strip()
+
+REICHARDT2006 = """
+@article{reichardt2006statistical,
+  title={Statistical mechanics of community detection},
+  author={Reichardt, J{\\"o}rg and Bornholdt, Stefan},
+  journal={Physical Review E},
+  volume={74},
+  number={1},
+  pages={016110},
+  year={2006},
+  publisher={APS}
+}
+""".strip()
+
+GOOD2010 = """
+@article{good2010performance,
+  title={Performance of modularity maximization in practical contexts},
+  author={Good, Benjamin H and De Montjoye, Yves-Alexandre and Clauset, Aaron},
+  journal={Physical Review E},
+  volume={81},
+  number={4},
+  pages={046106},
+  year={2010},
+  publisher={APS}
+}
+""".strip()
+
+SUN2008 = """
+@article{sun2009improved,
+  title={Improved community structure detection using a modified fine-tuning strategy},
+  author={Sun, Yudong and Danila, Bogdan and Josi{\'c}, K and Bassler, Kevin E},
+  journal={EPL (Europhysics Letters)},
+  volume={86},
+  number={2},
+  pages={28004},
+  year={2009},
+  publisher={IOP Publishing}
+}
+""".strip()
+
+BLONDEL2008 = """
+@article{blondel2008fast,
+  title={Fast unfolding of communities in large networks},
+  author={Blondel, Vincent D and Guillaume, Jean-Loup and Lambiotte, Renaud and Lefebvre, Etienne},
+  journal={Journal of statistical mechanics: theory and experiment},
+  volume={2008},
+  number={10},
+  pages={P10008},
+  year={2008},
+  publisher={IOP Publishing}
+}
+""".strip()
+
+GUIMERA2005 = """
+@article{guimera2005functional,
+  title={Functional cartography of complex metabolic networks},
+  author={Guimera, Roger and Amaral, Luis A Nunes},
+  journal={nature},
+  volume={433},
+  number={7028},
+  pages={895},
+  year={2005},
+  publisher={Nature Publishing Group}
+}
+""".strip()
+
+ZALESKY2010 = """
+@article{zalesky2010network,
+  title={Network-based statistic: identifying differences in brain networks},
+  author={Zalesky, Andrew and Fornito, Alex and Bullmore, Edward T},
+  journal={Neuroimage},
+  volume={53},
+  number={4},
+  pages={1197--1207},
+  year={2010},
+  publisher={Elsevier}
+}
+""".strip()
+
+MORRISON2005 = """
+@article{morrison2005generank,
+  title={GeneRank: using search engine technology for the analysis of microarray experiments},
+  author={Morrison, Julie L and Breitling, Rainer and Higham, Desmond J and Gilbert, David R},
+  journal={BMC bioinformatics},
+  volume={6},
+  number={1},
+  pages={233},
+  year={2005},
+  publisher={BioMed Central}
+}
+""".strip()
+
+BOLDI2009 = """
+@article{boldi2009pagerank,
+  title={PageRank: Functional dependencies.},
+  author={Boldi, Paolo and Santini, Massimo and Vigna, Sebastiano},
+  journal={ACM Trans. Inf. Syst.},
+  volume={27},
+  number={4},
+  pages={19--1},
+  year={2009},
+  publisher={Citeseer}
+}
+""".strip()
+
+MEILA2007 = """
+@article{meila2007comparing,
+  title={Comparing clusterings—an information based distance},
+  author={Meil{\\={a}}, Marina},
+  journal={Journal of multivariate analysis},
+  volume={98},
+  number={5},
+  pages={873--895},
+  year={2007},
+  publisher={Elsevier}
+}
+""".strip()
+
+BASSETT2010 = """
+@article{bassett2010efficient,
+  title={Efficient physical embedding of topologically complex information processing networks in brains and computer circuits},
+  author={Bassett, Danielle S and Greenfield, Daniel L and Meyer-Lindenberg, Andreas and Weinberger, Daniel R and Moore, Simon W and Bullmore, Edward T},
+  journal={PLoS computational biology},
+  volume={6},
+  number={4},
+  pages={e1000748},
+  year={2010},
+  publisher={Public Library of Science}
+}
+""".strip()
+
+COLIZZA2006 = """
+@article{colizza2006detecting,
+  title={Detecting rich-club ordering in complex networks},
+  author={Colizza, Vittoria and Flammini, Alessandro and Serrano, M Angeles and Vespignani, Alessandro},
+  journal={Nature physics},
+  volume={2},
+  number={2},
+  pages={110},
+  year={2006},
+  publisher={Nature Publishing Group}
+}
+""".strip()
+
+OPSAHL2008 = """
+@article{opsahl2008prominence,
+  title={Prominence and control: the weighted rich-club effect},
+  author={Opsahl, Tore and Colizza, Vittoria and Panzarasa, Pietro and Ramasco, Jose J},
+  journal={Physical review letters},
+  volume={101},
+  number={16},
+  pages={168702},
+  year={2008},
+  publisher={APS}
+}
+""".strip()
+
+HEUVEL2011 = """
+@article{van2011rich,
+  title={Rich-club organization of the human connectome},
+  author={Van Den Heuvel, Martijn P and Sporns, Olaf},
+  journal={Journal of Neuroscience},
+  volume={31},
+  number={44},
+  pages={15775--15786},
+  year={2011},
+  publisher={Soc Neuroscience}
+}
+""".strip()
+
+ESTRADA2005 = """
+@article{estrada2005subgraph,
+  title={Subgraph centrality in complex networks},
+  author={Estrada, Ernesto and Rodriguez-Velazquez, Juan A},
+  journal={Physical Review E},
+  volume={71},
+  number={5},
+  pages={056103},
+  year={2005},
+  publisher={APS}
+}
+""".strip()
+
+ESTRADA2010 = """
+@article{estrada2010network,
+  title={Network properties revealed through matrix functions},
+  author={Estrada, Ernesto and Higham, Desmond J},
+  journal={SIAM review},
+  volume={52},
+  number={4},
+  pages={696--714},
+  year={2010},
+  publisher={SIAM}
+}
+""".strip()
+
+HUMPHRIES2008 = """
+@article{humphries2008network,
+  title={Network ‘small-world-ness’: a quantitative method for determining canonical network equivalence},
+  author={Humphries, Mark D and Gurney, Kevin},
+  journal={PloS one},
+  volume={3},
+  number={4},
+  pages={e0002051},
+  year={2008},
+  publisher={Public Library of Science}
+}
+""".strip()

--- a/bct/citations.py
+++ b/bct/citations.py
@@ -217,6 +217,19 @@ NEWMAN2016 = """
 }
 """.strip()
 
+HONEY2007 = """
+@article{honey2007network,
+  title={Network structure of cerebral cortex shapes functional connectivity on multiple time scales},
+  author={Honey, Christopher J and K{\\"o}tter, Rolf and Breakspear, Michael and Sporns, Olaf},
+  journal={Proceedings of the National Academy of Sciences},
+  volume={104},
+  number={24},
+  pages={10240--10245},
+  year={2007},
+  publisher={National Acad Sciences}
+}
+"""
+
 YIP2007 = """
 @article{yip2007gene,
   title={Gene network interconnectedness and the generalized topological overlap measure},
@@ -256,7 +269,7 @@ MASLOV2002 = """
 }
 """.strip()
 
-SPOONS2004 = """
+SPORNS2004 = """
 @article{sporns2004small,
   title={The small world of the cerebral cortex},
   author={Sporns, Olaf and Zwi, Jonathan D},
@@ -486,6 +499,31 @@ HUMPHRIES2008 = """
   number={4},
   pages={e0002051},
   year={2008},
+  publisher={Public Library of Science}
+}
+""".strip()
+
+ZHANG2005 = """
+@article{zhang2005general,
+  title={A general framework for weighted gene co-expression network analysis},
+  author={Zhang, Bin and Horvath, Steve},
+  journal={Statistical applications in genetics and molecular biology},
+  volume={4},
+  number={1},
+  year={2005},
+  publisher={De Gruyter}
+}
+""".strip()
+
+COSTANTINI2014 = """
+@article{costantini2014generalization,
+  title={Generalization of clustering coefficients to signed correlation networks},
+  author={Costantini, Giulio and Perugini, Marco},
+  journal={PloS one},
+  volume={9},
+  number={2},
+  pages={e88669},
+  year={2014},
   publisher={Public Library of Science}
 }
 """.strip()

--- a/bct/citations.py
+++ b/bct/citations.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import unicode_literals
 from .version import __version__
 from datetime import datetime
@@ -401,7 +402,7 @@ BOLDI2009 = """
 
 MEILA2007 = """
 @article{meila2007comparing,
-  title={Comparing clusterings—an information based distance},
+  title={Comparing clusterings -- an information based distance},
   author={Meil{\\={a}}, Marina},
   journal={Journal of multivariate analysis},
   volume={98},

--- a/bct/due.py
+++ b/bct/due.py
@@ -1,0 +1,74 @@
+# emacs: at the end of the file
+# ex: set sts=4 ts=4 sw=4 et:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### #
+"""
+
+Stub file for a guaranteed safe import of duecredit constructs:  if duecredit
+is not available.
+
+To use it, place it into your project codebase to be imported, e.g. copy as
+
+    cp stub.py /path/tomodule/module/due.py
+
+Note that it might be better to avoid naming it duecredit.py to avoid shadowing
+installed duecredit.
+
+Then use in your code as
+
+    from .due import due, Doi, BibTeX, Text
+
+See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
+
+Origin:     Originally a part of the duecredit
+Copyright:  2015-2019  DueCredit developers
+License:    BSD-2
+"""
+
+__version__ = '0.0.8'
+
+
+class InactiveDueCreditCollector(object):
+    """Just a stub at the Collector which would not do anything"""
+    def _donothing(self, *args, **kwargs):
+        """Perform no good and no bad"""
+        pass
+
+    def dcite(self, *args, **kwargs):
+        """If I could cite I would"""
+        def nondecorating_decorator(func):
+            return func
+        return nondecorating_decorator
+
+    active = False
+    activate = add = cite = dump = load = _donothing
+
+    def __repr__(self):
+        return self.__class__.__name__ + '()'
+
+
+def _donothing_func(*args, **kwargs):
+    """Perform no good and no bad"""
+    pass
+
+
+try:
+    from duecredit import due, BibTeX, Doi, Url, Text
+    if 'due' in locals() and not hasattr(due, 'cite'):
+        raise RuntimeError(
+            "Imported due lacks .cite. DueCredit is now disabled")
+except Exception as e:
+    if not isinstance(e, ImportError):
+        import logging
+        logging.getLogger("duecredit").error(
+            "Failed to import duecredit due to %s" % str(e))
+    # Initiate due stub
+    due = InactiveDueCreditCollector()
+    BibTeX = Doi = Url = Text = _donothing_func
+
+# Emacs mode definitions
+# Local Variables:
+# mode: python
+# py-indent-offset: 4
+# tab-width: 4
+# indent-tabs-mode: nil
+# End:

--- a/bct/nbs.py
+++ b/bct/nbs.py
@@ -3,11 +3,14 @@ import numpy as np
 
 from .utils import BCTParamError, get_rng
 from .algorithms import get_components
+from .due import due, BibTeX
+from .citations import ZALESKY2010
 
 # FIXME considerable gains could be realized using vectorization, although
 # generating the null distribution will take a while
 
 
+@due.dcite(BibTeX(ZALESKY2010), description="Network-based statistic")
 def nbs_bct(x, y, thresh, k=1000, tail='both', paired=False, verbose=False, seed=None):
     '''
     Performs the NBS for populations X and Y for a t-statistic threshold of

--- a/bct/utils/visualization.py
+++ b/bct/utils/visualization.py
@@ -1,6 +1,8 @@
 from __future__ import division, print_function
 import numpy as np
 from .miscellaneous_utilities import BCTParamError
+from ..due import BibTeX, due
+from ..citations import HIDALGO2007, HAGMANN2008
 
 
 def adjacency_plot_und(A, coor, tube=False):
@@ -265,6 +267,8 @@ def align_matrices(m1, m2, dfun='sqrdiff', verbose=False, H=1e6, Texp=1,
     return M_reordered, M_indices, cost
 
 
+@due.dcite(BibTeX(HIDALGO2007), "Weighted undirected network backbone")
+@due.dcite(BibTeX(HAGMANN2008), "Weighted undirected network backbone")
 def backbone_wu(CIJ, avgdeg):
     '''
     The network backbone contains the dominant connections in the network

--- a/bct/version.py
+++ b/bct/version.py
@@ -1,0 +1,2 @@
+__version__ = '0.5.0'
+__version_info__ = tuple(int(i) for i in __version__.split('.'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy
 pytest
 setuptools
 tox
+duecredit

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,12 @@
 import pytest
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "long: mark test as long-running; skipped with --skiplong option"
+    )
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--skiplong", action="store_true", default=False, help="skip long-running tests"

--- a/test/duecredit_test.py
+++ b/test/duecredit_test.py
@@ -1,0 +1,64 @@
+import pytest
+import os
+import sys
+import subprocess as sp
+from datetime import datetime
+
+
+@pytest.fixture
+def script_path():
+    yield os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "simple_script.py"
+    )
+
+
+@pytest.fixture
+def dc_context(monkeypatch):
+    """Backup and delete duecredit cache, replacing it after the test, and enable duecredit"""
+    original = os.path.join(os.getcwd(), ".duecredit.p")
+    timestamp = datetime.utcnow().isoformat()
+    if os.name == "nt":
+        timestamp.replace(':', ';')
+    backup = original + '.' + timestamp
+    if os.path.isfile(original):
+        os.rename(original, backup)
+
+    monkeypatch.setenv("DUECREDIT_ENABLE", "yes")
+
+    yield
+
+    if os.path.isfile(original):
+        os.remove(original)
+    if os.path.isfile(backup):
+        os.rename(backup, original)
+
+
+def test_duecredit(script_path, dc_context):
+    result = sp.Popen([sys.executable, script_path])
+    result.wait()
+    assert result.returncode == 0
+
+    result2 = sp.Popen(["duecredit", "summary", "--format", "bibtex"], stdout=sp.PIPE)
+    result2.wait()
+    assert result2.returncode == 0
+
+    output = result2.stdout.read().decode("utf-8")
+    for author in [
+        "LaPlante",
+        "Latora",
+        "Onnela",
+        "Fagiolo",
+        "Rubinov",
+        "Leicht",
+        "Reichardt",
+        "Good",
+        "Maslov",
+    ]:
+        assert author in output
+
+    # fails due to bug 152
+    # assert output.count('@') == 10
+
+    headers = {line for line in output.split('\n') if line.startswith("@")}
+    assert len(headers) == 10

--- a/test/simple_script.py
+++ b/test/simple_script.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""Exercise some simple functions to make sure their citations are picked up"""
+import numpy as np
+import bct
+
+# Zachary karate club http://konect.cc/networks/ucidata-zachary/
+s = """
+1 2
+1 3
+2 3
+1 4
+2 4
+3 4
+1 5
+1 6
+1 7
+5 7
+6 7
+1 8
+2 8
+3 8
+4 8
+1 9
+3 9
+3 10
+1 11
+5 11
+6 11
+1 12
+1 13
+4 13
+1 14
+2 14
+3 14
+4 14
+6 17
+7 17
+1 18
+2 18
+1 20
+2 20
+1 22
+2 22
+24 26
+25 26
+3 28
+24 28
+25 28
+3 29
+24 30
+27 30
+2 31
+9 31
+1 32
+25 32
+26 32
+29 32
+3 33
+9 33
+15 33
+16 33
+19 33
+21 33
+23 33
+24 33
+30 33
+31 33
+32 33
+9 34
+10 34
+14 34
+15 34
+16 34
+19 34
+20 34
+21 34
+23 34
+24 34
+27 34
+28 34
+29 34
+30 34
+31 34
+32 34
+33 34
+""".strip()
+
+arr = np.zeros((34, 34), dtype=np.uint8)
+for row in s.split('\n'):
+    first, second = row.split(' ')
+    arr[int(first)-1, int(second)-1] += 1
+
+arr = bct.binarize(arr + arr.T)
+
+np.random.seed(1991)
+
+eff = bct.efficiency_bin(arr)
+mod = bct.modularity_und(arr)
+rand = bct.randmio_und_connected(arr, 5)


### PR DESCRIPTION
Information here: https://github.com/duecredit/duecredit

bctpy is mainly a repository of implementations of published graph theoretic measures. It would be nice to collect references to those publications automatically, rather than poring through the CREDITS file and every script in your analysis pipeline to see what gets called.

In most cases, duecredit does nothing and adds little to no performance overhead. However, when run with `DUECREDIT_ENABLE=yes`, citations for all registered packages you import and methods you call are put into a cache, which you can then read (or export as BibTeX) with `duecredit summary`. It's really neat!

This PR adds references for all functions specified in the CREDITS file, plus a few extras I found. A test is included. Also adds an [astropy-style](https://www.astropy.org/acknowledging.html) `__citation__` package attribute.