### PR TITLE
Remove EOL python, add GHA config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: test ${{ matrix.python_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - "3.10"
+          - "3.9"
+          - "3.8"
+          - "3.7"
+    steps:
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+      - uses: actions/checkout@v2
+      - name: Install tox-gh
+        run: python -m pip install tox-gh
+      - name: Setup test suite
+        run: tox -vv --notest
+      - name: Run test suite
+        run: tox --skip-pkg-install

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37}
+envlist = py{37,38,39,310}
 
 [testenv]
 deps = -rrequirements.txt
@@ -7,3 +7,10 @@ commands =
     pip install -U pip
     pip install .
     pytest --skiplong -v
+
+[gh]
+python =
+    3.7 = py37
+    3.8 = py38
+    3.9 = py39
+    3.10 = py310


### PR DESCRIPTION
I think travis is dead; certainly pythons 2.7-3.6 are.