### PR TITLE
Avoid ValueError in bct.modularity_dir with latest numpy version

### DIFF
--- a/bct/algorithms/modularity.py
+++ b/bct/algorithms/modularity.py
@@ -57,7 +57,7 @@ def ls2ci(ls, zeroindexed=False):
     ci : Nx1 np.ndarray
         community index vector
     '''
-    if ls is None or np.size(ls) == 0:
+    if ls is None or len(ls) == 0:
         return ()  # list is empty
     nr_indices = sum(map(len, ls))
     ci = np.zeros((nr_indices,), dtype=int)


### PR DESCRIPTION
`ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (3,) + inhomogeneous part.`

See details of what we try to solve on #119 