### PR TITLE
Fix shape check in modularity.py

### DIFF
--- a/bct/algorithms/modularity.py
+++ b/bct/algorithms/modularity.py
@@ -371,7 +371,7 @@ def link_communities(W, type_clustering='single'):
             dc = (mc - min_mc) / (nc * (nc - 1) /
                                   2 - min_mc)  # community density
 
-            if np.array(dc).shape is not ():
+            if np.array(dc).shape != ():
                 print(dc)
                 print(dc.shape)
 


### PR DESCRIPTION
This PR replaces an identity comparison with a literal tuple with a value-based comparison

Using `is not ()` triggers a SyntaxWarning in recent Python versions, since `is`/`is not` check object identity rather than equality. The intended behaviour is to check whether the shape tuple is non-empty, which is correctly expressed with `!= ()`.